### PR TITLE
Keypresses for shortcut key for "Add to Buffer"

### DIFF
--- a/chrome/options.html
+++ b/chrome/options.html
@@ -60,7 +60,6 @@
       <h2>Keyboard Shortcut</h2>
       <fieldset>
         <input type="text" placeholder="alt+b" name="key-combo">
-        <small>Keys separated by '+'. Eg. 'alt+shift+b' or 'ctrl+b'.</small>
         <small class="checkbox">
           <input type="checkbox" name="key-enable" value="key-enable" checked>Use key shortcut?
         </small>


### PR DESCRIPTION
This PR allows pressing keys inside the "Add to Buffer" shortcut key option field instead of having to manually write the name of the keys. For example, when the user presses the Control key, we populate the field with "ctrl".
