### PR TITLE
[PUB-1547] Replace jQuery ready method

### DIFF
--- a/chrome/data/chrome/options/options.js
+++ b/chrome/data/chrome/options/options.js
@@ -10,7 +10,7 @@ var isFramed = window.location.hash !== '#newtab';
 var framedStylesheet = document.querySelector('[data-use-when="framed"]');
 if (isFramed) framedStylesheet.setAttribute('href', framedStylesheet.getAttribute('data-href'));
 
-$(document).on('ready', function() {
+$(document).ready(function() {
   var currentBrowser = (
     location.protocol === 'chrome-extension:' ? 'chrome' :
     location.protocol === 'moz-extension:' ? 'firefox' : ''

--- a/chrome/data/chrome/options/telemetry-info.js
+++ b/chrome/data/chrome/options/telemetry-info.js
@@ -1,7 +1,7 @@
 // Remember that the popup was shown to user
 localStorage.setItem('buffer.op.firefox-disable-data-collection', 'null');
 
-$(document).on('ready', function() {
+$(document).ready(function() {
   $('.buttons-container button').on('click', function(e) {
     var $button = $(e.target);
     var choice = $button.attr('data-choice');


### PR DESCRIPTION
`$(document).on( "ready", handler )` was deprecated as of jQuery 1.8 and removed in jQuery 3.0.[docs](https://api.jquery.com/ready/)
Since we are using jQuery v3.4.1, the settings stopped working.
https://buffer.atlassian.net/browse/PUB-1547